### PR TITLE
Fix issue on amount when amount isn't specified

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://paystack.com/demo
 Tags: paystack, recurrent payments, nigeria, mastercard, visa, target, Naira, payments, verve, donation, church, NGO, form, contact form 7, form
 Requires at least: 3.1
 Tested up to: 5.0
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/paystack-forms.php
+++ b/paystack-forms.php
@@ -3,7 +3,7 @@
   Plugin Name:  Payment Forms for Paystack
   Plugin URI:   https://github.com/PaystackHQ/Wordpress-Payment-forms-for-Paystack
   Description:  Payment Forms for Paystack allows you create forms that will be used to bill clients for goods and services via Paystack.
-  Version:      3.2.3
+  Version:      3.2.4
   Author:       Paystack
   Author URI:   http://paystack.com
   License:      GPL-2.0+

--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -1345,7 +1345,8 @@ function kkd_pff_paystack_submit_action()
         'type' => 'text',
         'value' => $currency.number_format($amount)
     );
-    if ($usequantity == 'yes') {
+    if ($usequantity === 'yes' && !(($recur === 'optional') || ($recur === 'plan'))) {
+        print_r($recur);
         $quantity = $_POST["pf-quantity"];
         $unitamount = (int)str_replace(' ', '', $amount);
         $amount = $quantity*$unitamount;

--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -857,7 +857,7 @@ function kkd_pff_paystack_form_shortcode($atts)
                 echo '<span id="pf-min-val-warn" style="color: red; font-size: 13px;"></span> 
 				</div>
 			 </div>';
-                if ($recur == 'no' && $usequantity == 'yes' && ($usevariableamount == 1 || $amount != 0)) {
+                if ($recur == 'no' && $usequantity == 'yes') {  //&& ($usevariableamount == 1 || $amount != 0)) { //Commented out because the frontend stops transactions of 0 amount to go through
                     // if ($minimum == 0 && $recur == 'no' && $usequantity == 'yes' && $amount != 0) {
                     echo
                     '<div class="span12 unit">

--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -844,7 +844,7 @@ function kkd_pff_paystack_form_shortcode($atts)
                             $max = $quantity+1;
                             foreach ($paymentoptions as $key => $paymentoption) {
                                 list($a, $b) = explode(':', $paymentoption);
-                                echo '<option value="'.$b.'" data-name="'.$a.'">'.$a.'('.number_format($b).')</option>';
+                                echo '<option value="'.$b.'" data-name="'.$a.'">'.$a.' - '.$currency.' '.number_format($b).'</option>';
                             }
                             echo '</select> <i></i> </div>';
                         }
@@ -1314,7 +1314,6 @@ function kkd_pff_paystack_submit_action()
     $usevariableamount = get_post_meta($_POST["pf-id"], '_usevariableamount', true);
     $amount = (int)str_replace(' ', '', $_POST["pf-amount"]);
     $variablename = $_POST["pf-vname"];
-    // pf-vname
     $originalamount = $amount;
     $quantity = 1;
     $usequantity = get_post_meta($_POST["pf-id"], '_usequantity', true);

--- a/public/js/paystack-forms-public.js
+++ b/public/js/paystack-forms-public.js
@@ -89,7 +89,6 @@ function KkdPffPaystackFee() {
           nextText: '<i class="fa fa-caret-right"></i>'
         });
       });
-      var international_card = false;
       if ($("#pf-vamount").length) {
         var amountField = $("#pf-vamount");
         calculateTotal();
@@ -164,7 +163,12 @@ function KkdPffPaystackFee() {
       };
   
       function calculateTotal() {
-        var unit = $("#pf-amount").val();
+        var unit;
+        if ($("#pf-vamount").length) {
+            unit = $("#paystack-form").find("#pf-vamount").val();
+        } else {
+            unit = $("#pf-amount").val();
+        }
         var quant = $("#pf-quantity").val();
         var newvalue = unit * quant;
         
@@ -237,7 +241,7 @@ function KkdPffPaystackFee() {
           }
         }
       });
-      $("#pf-quantity,#pf-vamount, #pf-amount").on("change", function() {
+      $("#pf-quantity, #pf-vamount, #pf-amount").on("change", function() {
         calculateTotal();
         calculateFees();
       });
@@ -263,9 +267,15 @@ function KkdPffPaystackFee() {
                 var email = $(this)
                     .find("#pf-email")
                     .val();
-                var amount = $(this)
+                var amount;
+                if ($("#pf-vamount").length) {
+                    amount = $("#paystack-form").find("#pf-vamount").val();
+                    calculateTotal();
+                } else {
+                    amount = $(this)
                     .find("#pf-amount")
                     .val();
+                } 
                 if (Number(amount) > 0) {
                 } else {
                     $(this)


### PR DESCRIPTION
When `amount` is open, quantity should show.
The frontend prevents the form from being submitted and this fixes a bug
where `amount` is not being sent because `amount` is being multiplied by 0 `quantity`