### PR TITLE
Remove `print_r` call

### DIFF
--- a/public/class-paystack-forms-public.php
+++ b/public/class-paystack-forms-public.php
@@ -1346,7 +1346,6 @@ function kkd_pff_paystack_submit_action()
         'value' => $currency.number_format($amount)
     );
     if ($usequantity === 'yes' && !(($recur === 'optional') || ($recur === 'plan'))) {
-        print_r($recur);
         $quantity = $_POST["pf-quantity"];
         $unitamount = (int)str_replace(' ', '', $amount);
         $amount = $quantity*$unitamount;


### PR DESCRIPTION
This prevented the call to the Paystack API to be made.
Should not have been comitted sef, what was I thinking.
This is why we should have code reviews