### PR TITLE
Add 'paid_at' column to database on initial installation

### DIFF
--- a/includes/class-paystack-forms-activator.php
+++ b/includes/class-paystack-forms-activator.php
@@ -25,6 +25,7 @@ class Kkd_Pff_Paystack_Activator
 		  	ip varchar(255) NOT NULL, 
 			deleted_at varchar(255) DEFAULT '' NULL,
 			created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			paid_at timestamp,
 		  	modified timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
 		  	UNIQUE KEY id (id),PRIMARY KEY  (id)
 		) $charset_collate;";


### PR DESCRIPTION
When initially installing this, the `paid_at `column is not included in the installation script, and this is needed when transactions are being updated in the database. 

This fixes the issue.